### PR TITLE
fixed "apt: command not found" error

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,8 +13,8 @@ INSTALL_DIR=${INSTALL_DIR_PARENT}${SCRIPT_NAME}/
 mkdir -p "/etc/turbolab.it/"
 
 ## Pre-requisites
-apt update
-apt install git -y
+sudo apt-get update
+sudo apt-get install git -y
 
 ## Install/update
 echo ""


### PR DESCRIPTION
When trying to install I got the following errors:
/usr/local/turbolab.it/zzupdate/setup.sh: line 16: apt: command not found
/usr/local/turbolab.it/zzupdate/setup.sh: line 17: apt: command not found
I might be mistaken but did you mean apt-get?